### PR TITLE
Add more cursor functions

### DIFF
--- a/src/cursor.zig
+++ b/src/cursor.zig
@@ -4,7 +4,11 @@ const Esc = "\x1B";
 const Csi = Esc ++ "[";
 
 pub fn hideCursor(writer: anytype) !void {
-    try writer.writeAll(Csi ++ "?25hl");
+    try writer.writeAll(Csi ++ "?25l");
+}
+
+pub fn showCursor(writer: anytype) !void {
+    try writer.writeAll(Csi ++ "?25h");
 }
 
 pub fn saveCursor(writer: anytype) !void {
@@ -17,6 +21,14 @@ pub fn restoreCursor(writer: anytype) !void {
 
 pub fn setCursor(writer: anytype, x: usize, y: usize) !void {
     try writer.print(Csi ++ "{};{}H", .{ y + 1, x + 1 });
+}
+
+pub fn setCursorRow(writer: anytype, row: usize) !void {
+    try writer.print(Csi ++ "{}H", .{row + 1});
+}
+
+pub fn setCursorColumn(writer: anytype, column: usize) !void {
+    try writer.print(Csi ++ "{}G", .{column + 1});
 }
 
 pub fn cursorUp(writer: anytype, lines: usize) !void {
@@ -33,4 +45,20 @@ pub fn cursorForward(writer: anytype, columns: usize) !void {
 
 pub fn cursorBackward(writer: anytype, columns: usize) !void {
     try writer.print(Csi ++ "{}D", .{columns});
+}
+
+pub fn cursorNextLine(writer: anytype, lines: usize) !void {
+    try writer.print(Csi ++ "{}E", .{lines});
+}
+
+pub fn cursorPreviousLine(writer: anytype, lines: usize) !void {
+    try writer.print(Csi ++ "{}F", .{lines});
+}
+
+pub fn scrollUp(writer: anytype, lines: usize) !void {
+    try writer.print(Csi ++ "{}S", .{lines});
+}
+
+pub fn scrollDown(writer: anytype, lines: usize) !void {
+    try writer.print(Csi ++ "{}T", .{lines});
 }


### PR DESCRIPTION
And fixes `hideCursor`'s bug.

Ref: https://en.wikipedia.org/wiki/ANSI_escape_code#Terminal_output_sequences